### PR TITLE
Add dependency on rexml

### DIFF
--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency('i18n', '>= 0.6.9')
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
   s.add_dependency('nokogiri', '~> 1.4')
+  s.add_dependency('rexml', '~> 3.2.5')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('test-unit', '~> 3')

--- a/lib/active_merchant/version.rb
+++ b/lib/active_merchant/version.rb
@@ -1,3 +1,3 @@
 module ActiveMerchant
-  VERSION = '1.104.0'
+  VERSION = '1.104.1'
 end


### PR DESCRIPTION
### LINK ASSOCIATED WITH THIS PULL REQUEST
[Ticket Link](https://www.example.com)

### DESCRIPTION OF PULL REQUEST

ActiveMerchant depends on the rexml gem, but our fork did not specify it in the gemspec.
We used to have it in DPE because of some development/test gems, but now we're not installing them in other envs anymore.

### IMPACT ASSESSMENT

###### ACCESS - DOES THIS PULL REQUEST IMPACT PLATFORM ROLES, PASSWORDS, OR SESSION CONFIGURATIONS?
- [x] No
- [ ] Yes. Please describe the change:

###### DEPLOYMENT - DOES THIS PULL REQUEST REQUIRE DEPLOYMENT CHANGES?
- [x] No
- [ ] Yes. Please describe the change:

###### COMPONENTS - WAS A NEW COMPONENT (RUBY GEM, JAVASCRIPT PACKAGE) INTRODUCED TO THE CODE BASE?
- [x] No
- [ ] Yes. Please describe the change:

###### SECURITY - DOES THIS PULL REQUEST IMPACT OUR API (NEW OR MODIFIED ENDPOINTS OR CHANGES TO REQUEST AND RESPONSE BODY)
- [x] No
- [ ] Yes. Please describe the change:

###### LOGGING - DOES THIS PULL REQUEST IMPACT HOW WE LOG (3RD PARTIES, LOG DATA, LOCATION OF LOGS)
- [x] No
- [ ] Yes. Please describe the change:

###### ENCRYPTION - DOES THIS PULL REQUEST IMPACT OUR ENCRYPTION LEVELS (IN TRANSIT OR AT REST)
- [x] No
- [ ] Yes. Please describe the change:

++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

[PayWith Code Review Checklist](https://sites.google.com/paywith.com/paywith-wiki/development/procedures/change-management/code-review-checklist?authuser=0)